### PR TITLE
Add support of ec2 instance termination

### DIFF
--- a/.terraform-docs.yml
+++ b/.terraform-docs.yml
@@ -24,8 +24,7 @@ output:
 
 sort:
   enabled: true
-  by:
-    - required
+  by: required
 
 settings:
   anchor: true

--- a/README.md
+++ b/README.md
@@ -105,39 +105,40 @@ aws lambda invoke --function-name <function_name_from_output> --payload '{"actio
 
 ## Providers
 
-| Name                                                         | Version |
-| ------------------------------------------------------------ | ------- |
-| <a name="provider_archive"></a> [archive](#provider_archive) | >= 2    |
-| <a name="provider_aws"></a> [aws](#provider_aws)             | >= 3    |
+| Name | Version |
+|------|---------|
+| <a name="provider_archive"></a> [archive](#provider\_archive) | 2.3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.59.0 |
 
 ## Inputs
 
-| Name                                                                                                            | Description                                                                                                                                                                    | Type                                                                                                                                | Default | Required |
-| --------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------- | ------- | :------: |
-| <a name="input_name"></a> [name](#input_name)                                                                   | A name used to create resources in module                                                                                                                                      | `string`                                                                                                                            | n/a     |   yes    |
-| <a name="input_schedules"></a> [schedules](#input_schedules)                                                    | List of map containing, the following keys: name (for jobs name), start (cron for the start schedule), stop (cron for stop schedule), tag_key and tag_value (target recources) | <pre>list(object({<br> name = string<br> start = string<br> stop = string<br> tag_key = string<br> tag_value = string<br> }))</pre> | n/a     |   yes    |
-| <a name="input_asg_schedule"></a> [asg_schedule](#input_asg_schedule)                                           | Run the scheduler on AutoScalingGroup.                                                                                                                                         | `bool`                                                                                                                              | `true`  |    no    |
-| <a name="input_aws_regions"></a> [aws_regions](#input_aws_regions)                                              | List of AWS region where the scheduler will be applied. By default target the current region.                                                                                  | `list(string)`                                                                                                                      | `null`  |    no    |
-| <a name="input_custom_iam_lambda_role"></a> [custom_iam_lambda_role](#input_custom_iam_lambda_role)             | Use a custom role used for the lambda. Useful if you cannot create IAM ressource directly with your AWS profile, or to share a role between several resources.                 | `bool`                                                                                                                              | `false` |    no    |
-| <a name="input_custom_iam_lambda_role_arn"></a> [custom_iam_lambda_role_arn](#input_custom_iam_lambda_role_arn) | Custom role arn used for the lambda. Used only if custom_iam_lambda_role is set to true.                                                                                       | `string`                                                                                                                            | `null`  |    no    |
-| <a name="input_lambda_timeout"></a> [lambda_timeout](#input_lambda_timeout)                                     | Amount of time your Lambda Function has to run in seconds.                                                                                                                     | `number`                                                                                                                            | `10`    |    no    |
-| <a name="input_rds_schedule"></a> [rds_schedule](#input_rds_schedule)                                           | Run the scheduler on RDS.                                                                                                                                                      | `bool`                                                                                                                              | `true`  |    no    |
-| <a name="input_tags"></a> [tags](#input_tags)                                                                   | Custom Resource tags                                                                                                                                                           | `map(string)`                                                                                                                       | `{}`    |    no    |
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_name"></a> [name](#input\_name) | A name used to create resources in module | `string` | n/a | yes |
+| <a name="input_schedules"></a> [schedules](#input\_schedules) | List of map containing, the following keys: name (for jobs name), start (cron for the start schedule), stop (cron for stop schedule), tag\_key and tag\_value (target recources) | <pre>list(object({<br>    name      = string<br>    start     = string<br>    stop      = string<br>    tag_key   = string<br>    tag_value = string<br>  }))</pre> | n/a | yes |
+| <a name="input_asg_schedule"></a> [asg\_schedule](#input\_asg\_schedule) | Run the scheduler on AutoScalingGroup. | `bool` | `true` | no |
+| <a name="input_aws_regions"></a> [aws\_regions](#input\_aws\_regions) | List of AWS region where the scheduler will be applied. By default target the current region. | `list(string)` | `null` | no |
+| <a name="input_custom_iam_lambda_role"></a> [custom\_iam\_lambda\_role](#input\_custom\_iam\_lambda\_role) | Use a custom role used for the lambda. Useful if you cannot create IAM ressource directly with your AWS profile, or to share a role between several resources. | `bool` | `false` | no |
+| <a name="input_custom_iam_lambda_role_arn"></a> [custom\_iam\_lambda\_role\_arn](#input\_custom\_iam\_lambda\_role\_arn) | Custom role arn used for the lambda. Used only if custom\_iam\_lambda\_role is set to true. | `string` | `null` | no |
+| <a name="input_ec2_schedule"></a> [ec2\_schedule](#input\_ec2\_schedule) | Run the scheduler on EC2 instances. (only allows downscaling) | `bool` | `false` | no |
+| <a name="input_lambda_timeout"></a> [lambda\_timeout](#input\_lambda\_timeout) | Amount of time your Lambda Function has to run in seconds. | `number` | `10` | no |
+| <a name="input_rds_schedule"></a> [rds\_schedule](#input\_rds\_schedule) | Run the scheduler on RDS. | `bool` | `true` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Custom Resource tags | `map(string)` | `{}` | no |
 
 ## Outputs
 
-| Name                                                                                                                          | Description                                                          |
-| ----------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
-| <a name="output_clouwatch_event_rules"></a> [clouwatch_event_rules](#output_clouwatch_event_rules)                            | Cloudwatch event rules generated by the module to trigger the lambda |
-| <a name="output_lambda_function_arn"></a> [lambda_function_arn](#output_lambda_function_arn)                                  | The ARN of the Lambda function                                       |
-| <a name="output_lambda_function_invoke_arn"></a> [lambda_function_invoke_arn](#output_lambda_function_invoke_arn)             | The ARN to be used for invoking Lambda function from API Gateway     |
-| <a name="output_lambda_function_last_modified"></a> [lambda_function_last_modified](#output_lambda_function_last_modified)    | The date Lambda function was last modified                           |
-| <a name="output_lambda_function_log_group_arn"></a> [lambda_function_log_group_arn](#output_lambda_function_log_group_arn)    | The ARN of the lambda's log group                                    |
-| <a name="output_lambda_function_log_group_name"></a> [lambda_function_log_group_name](#output_lambda_function_log_group_name) | The name of the lambda's log group                                   |
-| <a name="output_lambda_function_name"></a> [lambda_function_name](#output_lambda_function_name)                               | The name of the Lambda function                                      |
-| <a name="output_lambda_function_version"></a> [lambda_function_version](#output_lambda_function_version)                      | Latest published version of your Lambda function                     |
-| <a name="output_lambda_iam_role_arn"></a> [lambda_iam_role_arn](#output_lambda_iam_role_arn)                                  | The ARN of the IAM role used by Lambda function                      |
-| <a name="output_lambda_iam_role_name"></a> [lambda_iam_role_name](#output_lambda_iam_role_name)                               | The name of the IAM role used by Lambda function                     |
+| Name | Description |
+|------|-------------|
+| <a name="output_clouwatch_event_rules"></a> [clouwatch\_event\_rules](#output\_clouwatch\_event\_rules) | Cloudwatch event rules generated by the module to trigger the lambda |
+| <a name="output_lambda_function_arn"></a> [lambda\_function\_arn](#output\_lambda\_function\_arn) | The ARN of the Lambda function |
+| <a name="output_lambda_function_invoke_arn"></a> [lambda\_function\_invoke\_arn](#output\_lambda\_function\_invoke\_arn) | The ARN to be used for invoking Lambda function from API Gateway |
+| <a name="output_lambda_function_last_modified"></a> [lambda\_function\_last\_modified](#output\_lambda\_function\_last\_modified) | The date Lambda function was last modified |
+| <a name="output_lambda_function_log_group_arn"></a> [lambda\_function\_log\_group\_arn](#output\_lambda\_function\_log\_group\_arn) | The ARN of the lambda's log group |
+| <a name="output_lambda_function_log_group_name"></a> [lambda\_function\_log\_group\_name](#output\_lambda\_function\_log\_group\_name) | The name of the lambda's log group |
+| <a name="output_lambda_function_name"></a> [lambda\_function\_name](#output\_lambda\_function\_name) | The name of the Lambda function |
+| <a name="output_lambda_function_version"></a> [lambda\_function\_version](#output\_lambda\_function\_version) | Latest published version of your Lambda function |
+| <a name="output_lambda_iam_role_arn"></a> [lambda\_iam\_role\_arn](#output\_lambda\_iam\_role\_arn) | The ARN of the IAM role used by Lambda function |
+| <a name="output_lambda_iam_role_name"></a> [lambda\_iam\_role\_name](#output\_lambda\_iam\_role\_name) | The name of the IAM role used by Lambda function |
 
 <!-- END_TF_DOCS -->
 

--- a/function/scheduler/autoscaling.py
+++ b/function/scheduler/autoscaling.py
@@ -156,7 +156,7 @@ def list_asg_by_tags(tag_key: str, tag_value: str) -> List[AutoScalingGroup]:
     for cluster in clusters:
         for page in paginator_list_nodegroups.paginate(clusterName = cluster):
              list_clusters_node_groups.append({'cluster_name':cluster, 'node_groups': page['nodegroups']})
-    
+
     ## List node group with tags
     node_group_with_tag = []
     for association in list_clusters_node_groups:

--- a/function/scheduler/ec2.py
+++ b/function/scheduler/ec2.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+
+"""
+EC2 instances scheduler.
+"""
+import logging
+from dataclasses import dataclass
+from typing import Dict, Iterator, List, Any
+
+import boto3
+from botocore.exceptions import ClientError
+
+
+logger = logging.getLogger()
+
+
+@dataclass
+class EC2Instance:
+    """EC2 Instance"""
+
+    instance_id: str
+    ec2: Any
+
+    def stop(self) -> None:
+        """
+        Stop AWS EC2 instance
+        """
+        try:
+            self.ec2.stop_instances(InstanceIds=[self.instance_id])
+            logger.info(f"Stopped EC2 instance {self.instance_id}")
+        except ClientError as exc:
+            logger.warn(exc)
+
+
+def list_ec2_by_tags(tag_key: str, tag_value: str) -> List[EC2Instance]:
+    """
+    List AWS EC2 instances with the specified tag key and value.
+    """
+
+    ec2 = boto3.client("ec2")
+    rgta = boto3.client("resourcegroupstaggingapi")
+
+    ec2_list = []
+    paginator = rgta.get_paginator("get_resources")
+    page_iterator = paginator.paginate(
+        TagFilters=[{"Key": tag_key, "Values": [tag_value]}],
+        ResourceTypeFilters=["ec2:instance"],
+    )
+
+    for page in page_iterator:
+        for resource_tag_map in page["ResourceTagMappingList"]:
+            instance_id = resource_tag_map["ResourceARN"].split(":")[-1].split("/")[-1]
+            ec2_list.append(EC2Instance(instance_id=instance_id, ec2=ec2))
+
+    return ec2_list

--- a/function/scheduler/ec2.py
+++ b/function/scheduler/ec2.py
@@ -26,7 +26,7 @@ class EC2Instance:
         Stop AWS EC2 instance
         """
         try:
-            self.ec2.stop_instances(InstanceIds=[self.instance_id])
+            self.ec2.terminate_instances(InstanceIds=[self.instance_id])
             logger.info(f"Stopped EC2 instance {self.instance_id}")
         except ClientError as exc:
             logger.warn(exc)

--- a/main.tf
+++ b/main.tf
@@ -105,7 +105,6 @@ resource "aws_iam_role_policy" "lambda_rds" {
 data "aws_iam_policy_document" "lambda_ec2" {
   statement {
     actions = [
-      "ec2:StopInstances",
       "ec2:TerminateInstances",
     ]
 

--- a/main.tf
+++ b/main.tf
@@ -131,6 +131,7 @@ resource "aws_lambda_function" "start_stop_scheduler" {
       AWS_REGIONS  = var.aws_regions == null ? data.aws_region.current.name : join(", ", var.aws_regions)
       RDS_SCHEDULE = tostring(var.rds_schedule)
       ASG_SCHEDULE = tostring(var.asg_schedule)
+      EC2_SCHEDULE = tostring(var.ec2_schedule)
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -102,6 +102,27 @@ resource "aws_iam_role_policy" "lambda_rds" {
   policy      = data.aws_iam_policy_document.lambda_rds.json
 }
 
+data "aws_iam_policy_document" "lambda_ec2" {
+  statement {
+    actions = [
+      "ec2:StopInstances",
+      "ec2:TerminateInstances",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "lambda_ec2" {
+  count = var.custom_iam_lambda_role ? 0 : 1
+
+  name_prefix = "${local.name_prefix}_ec2"
+  role        = aws_iam_role.lambda[0].id
+  policy      = data.aws_iam_policy_document.lambda_ec2.json
+}
+
 data "archive_file" "lambda_zip" {
   type        = "zip"
   source_dir  = "${path.module}/function/"

--- a/variables.tf
+++ b/variables.tf
@@ -47,6 +47,12 @@ variable "asg_schedule" {
   type        = bool
 }
 
+variable "ec2_schedule" {
+  default     = false
+  description = "Run the scheduler on EC2 instances. (only allows downscaling)"
+  type        = bool
+}
+
 variable "aws_regions" {
   default     = null
   description = "List of AWS region where the scheduler will be applied. By default target the current region."


### PR DESCRIPTION
This PR proposes an implementation of an EC2 scale down only algorithm.

Our use case for this is the scale down of Karpenter nodes at night to save on the bill. Karpenter do not have support for cron scaling.